### PR TITLE
Avoid unexpected image loading

### DIFF
--- a/pages/books/[id].vue
+++ b/pages/books/[id].vue
@@ -248,7 +248,7 @@ const book = computed(() => {
       title: "loading...",
       author: "loading...",
       publisher: "loading...",
-      thumbnail: "loading..."
+      thumbnail: ""
     }
   }
 })


### PR DESCRIPTION
Unexpected image loading `/books/loading... ` occurred sometimes when loading the initial page.
Fixed to avoid this.